### PR TITLE
7607 documentation (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,73 @@
 # Unreal QT Framework
 
 This is a helper library designed to be used in 
-conjunction with the [tk-unreal](https://github.com/shotgunsoftware/tk-unreal) engine.
+conjunction with the [tk-unreal](https://github.com/ue4plugins/tk-unreal) engine.
+
+This framework contains hooks which can be re-used in configurations where the
+Unreal integration is needed, and PySide2 binaries needed to run the SG Toolkit
+integration in Unreal.
 
 Please see the engine for more details.
+
+## The PySide2 libraries
+
+Binaries for PySide2 libraries for all platforms are not included in the
+source tree and must be built before being able to use this framework.
+
+### Building the PySide2 libraries locally
+
+Use the [build_packages.sh](resources/build_packages.sh) script with the `-b` option to build and install 
+the packages specified in the [requirements.txt](resources/requirements.txt) file.
+```
+Usage : ./build_packages.sh [-h] [-b] [-p <python command]
+Options :
+ -h : show this help message
+ -b : build packages into their shipping destination
+ -p : specify which python command to use, e.g. python, python2, python3
+```
+The framework can be used with a local descriptor (e.g. dev or path) once the 
+binaries are build. 
+
+### Building the PySide2 libraries with Azure Pipelines
+
+The [build_packages.sh](resources/build_packages.sh) script can be used with [Azure Pipelines](https://docs.microsoft.com/en-us/azure/devops/pipelines/get-started/pipelines-get-started?view=azure-devops) 
+to automatically build the packages each time a new version tag is added in Github.
+
+You can get access to Azure Pipelines for free [from your Github account](https://docs.microsoft.com/en-us/azure/devops/pipelines/get-started/pipelines-sign-up?view=azure-devops#sign-up-with-a-github-account)
+if you don't already have an account.
+
+You can use the provided [azure-pipelines.yml](azure-pipelines.yml) file to create a [new Azure Pipeline](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#access-to-github-repositories).
+
+A [service connection to Github](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#permissions-needed-in-github-1)
+ will have to be created if you don't already have one.
+
+The Azure pipeline builds the PySide2 libraries for Windows, Linux and Mac, and upload them to Github releases.
+
+<img width="512" alt="Github releases" src="https://user-images.githubusercontent.com/39291844/153920988-0dcb80d3-3c37-479d-8079-33496f8952f4.png">
+
+## Using this framework in your Setup
+
+Add this framework in the `frameworks` settings section of the Toolkit application needing
+it. 
+For example:
+
+```
+frameworks:
+     - {"name": "tk-framework-unrealqt", "version": "v1.x.x"}
+```
+
+- If you're using a local descriptor (dev or path) you need to build the PySide2 libraries
+yourself. See [building the PySide2 libraries locally](#building-the-pyside2-libraries-locally).
+
+- If you're using a remote descriptor, just in time download must be added so these binaries are downloaded in SG TK bootstrap process. The provided [bootstrap.py](hooks/core/bootstrap.py) script implements just in time downloads from Github releases with a `git` descriptor:
+   - Copy the `hooks/core/bootstrap.py` file to your config `core/hooks/bootstrap.py`
+hook.
+   - Use a `git` descriptor for the framework, e.g.:
+      ```
+      tk-framework-unrealqt_v1.x.x:
+        location:
+          version: v1.2.5
+          type: git
+          path: git@github.com:ue4plugins/tk-framework-unrealqt.git
+      ```
+

--- a/hooks/core/bootstrap.py
+++ b/hooks/core/bootstrap.py
@@ -1,0 +1,246 @@
+# This file is provided by Epic Games, Inc. and is subject to the license
+# file included in this repository.
+
+"""
+This hook is used override some of the functionality of the :class:`~sgtk.bootstrap.ToolkitManager`.
+
+It will be instantiated only after a configuration has been selected by the :class:`~sgtk.bootstrap.ToolkitManager`.
+Therefore, this hook will not be invoked to download a configuration. However, the Toolkit Core,
+applications, frameworks and engines can be downloaded through the hook.
+"""
+
+import os
+import zipfile
+import json
+import platform
+import re
+
+from sgtk import get_hook_baseclass
+
+
+_SIX_IMPORT_WARNING = (
+    "Unable to import six.moves from tk-core, this can happen "
+    "if an old version of tk-core < 0.19.1 is used in a site "
+    "pipeline configuration. Falling back on using urllib2."
+)
+
+
+class Bootstrap(get_hook_baseclass()):
+    """
+    Override the bootstrap core hook to cache some bundles ourselves.
+    http://developer.shotgunsoftware.com/tk-core/core.html#bootstrap.Bootstrap
+    """
+    # List of github repos for which we download releases, with a github token to
+    # do the download if the repo is private
+    _download_release_from_github = [
+        ("ue4plugins/tk-framework-unrealqt", ""),
+        ("GPLgithub/tk-framework-unrealqt", ""),
+    ]
+
+    def can_cache_bundle(self, descriptor):
+        """
+        Indicates if a bundle can be cached by the :meth:`populate_bundle_cache_entry` method.
+
+        This method is invoked when the bootstrap manager wants to cache a bundle used by a configuration.
+
+        .. note:: This method is not called if the bundle is already cached so it
+                  can't be used to update an existing cached bundle.
+
+        :param descriptor: Descriptor of the bundle that needs to be cached.
+
+        :returns: ``True`` if the bundle can be cached with this hook, ``False``
+                  if not.
+        :rtype: bool
+        :raises RuntimeError: If six.moves is not available.
+        """
+        descd = descriptor.get_dict()
+        # Some descriptors like shotgun descriptors don't have a path: ignore
+        # them.
+        if not descd.get("path"):
+            return False
+        return bool(self._should_download_release(descd["path"]))
+
+    def populate_bundle_cache_entry(self, destination, descriptor, **kwargs):
+        """
+        Populates an entry from the bundle cache.
+
+        This method will be invoked for every bundle for which :meth:`can_cache_bundle`
+        returned ``True``. The hook is responsible for writing the bundle inside
+        the destination folder. If an exception is raised by this method, the files
+        will be deleted from disk and the bundle cache will be left intact.
+
+        It has to properly copy all the files or the cache for this bundle
+        will be left in an inconsistent state.
+
+        :param str destination: Folder where the bundle needs to be written. Note
+            that this is not the final destination folder inside the bundle cache.
+
+        :param descriptor: Descriptor of the bundle that needs to be cached.
+        """
+        # This logic can be removed once we can assume tk-core is > v0.19.1 not
+        # just in configs but also in the bundled Shotgun.app.
+        try:
+            from tank_vendor.six.moves.urllib import request as url2
+            from tank_vendor.six.moves.urllib import error as error_url2
+        except ImportError as e:
+            self.logger.warning(_SIX_IMPORT_WARNING)
+            self.logger.debug("%s" % e, exc_info=True)
+            # Fallback on using urllib2
+            import urllib2 as url2
+            import urllib2 as error_url2
+
+        descd = descriptor.get_dict()
+        version = descriptor.version
+        self.logger.info("Treating %s" % descd)
+        specs = self._should_download_release(descd["path"])
+        if not specs:
+            raise RuntimeError("Don't know how to download %s" % descd)
+        name = specs[0]
+        token = specs[1]
+        try:
+            if self.shotgun.config.proxy_handler:
+                # Re-use proxy settings from the Shotgun connection
+                opener = url2.build_opener(
+                    self.parent.shotgun.config.proxy_handler,
+                )
+                url2.install_opener(opener)
+
+            # Retrieve the release from the tag
+            url = "https://api.github.com/repos/%s/releases/tags/%s" % (name, version)
+            request = url2.Request(url)
+            # Add the authorization token if we have one (private repos)
+            if token:
+                request.add_header("Authorization", "token %s" % token)
+            request.add_header("Accept", "application/vnd.github.v3+json")
+            try:
+                response = url2.urlopen(request)
+            except error_url2.URLError as e:
+                if hasattr(e, "code"):
+                    if e.code == 404:
+                        self.logger.error("Release %s does not exists" % version)
+                    elif e.code == 401:
+                        self.logger.error("Not authorised to access release %s." % version)
+                raise
+            response_d = json.loads(response.read())
+            # Look up for suitable assets for this platform. Assets names
+            # follow this convention:
+            #  <version>-py<python version>-<platform>.zip
+            # We download and extract all assets for any Python version for
+            # the current platform and version. We're assuming that the cached
+            # config for a user will never be shared between machines with
+            # different os.
+            pname = {
+                "Darwin": "osx",
+                "Linux": "linux",
+                "Windows": "win"
+            }.get(platform.system())
+
+            if not pname:
+                raise ValueError("Unsupported platform %s" % platform.system())
+
+            extracted = []
+            for asset in response_d["assets"]:
+                name = asset["name"]
+                m = re.match(
+                    "%s-py\d.\d-%s.zip" % (version, pname),
+                    name
+                )
+                if m:
+                    # Download the asset payload
+                    self._download_zip_github_asset(
+                        asset,
+                        destination,
+                        token
+                    )
+                    extracted.append(asset)
+
+            if not extracted:
+                raise RuntimeError(
+                    "Couldn't retrieve a suitable asset from %s" % [
+                        a["name"] for a in response_d["assets"]
+                    ]
+                )
+            self.logger.info(
+                "Extracted files: %s from %s" % (
+                    os.listdir(destination),
+                    ",".join([a["name"] for a in extracted])
+                )
+            )
+        except Exception as e:
+            # Log the exception with the backtrace because TK obfuscates it.
+            self.logger.exception(e)
+            raise
+
+    def _should_download_release(self, desc_path):
+        """
+        Return a repo name and a token if the given descriptor path should be downloaded
+        from a github release.
+
+        :param str desc_path: A Toolkit descriptor path.
+        :returns: A name, token tuple or ``None``.
+        """
+        for name, token in self._download_release_from_github:
+            if "git@github.com:%s.git" % name == desc_path:
+                return name, token
+        return None
+
+    def _download_zip_github_asset(self, asset, destination, token):
+        """
+        Download the zipped github asset and extract it into the given destination
+        folder.
+
+        Assets can be retrieved with the releases github REST api endpoint.
+        https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name
+
+        :param str asset: A Github asset dictionary.
+        :param str destination: Full path to a folder where to extract the downloaded
+                            zipped archive. The folder is created if it does not
+                            exist.
+        :param str token: A Github OAuth or personal token.
+        """
+        try:
+            from tank_vendor.six.moves.urllib import request as url2
+        except ImportError as e:
+            self.logger.warning(_SIX_IMPORT_WARNING)
+            self.logger.debug("%s" % e, exc_info=True)
+            # Fallback on using urllib2
+            import urllib2 as url2
+        # If we have a token use a basic auth handler
+        # just a http handler otherwise
+        if token:
+            passman = url2.HTTPPasswordMgrWithDefaultRealm()
+            passman.add_password(
+                None,
+                asset["url"],
+                token,
+                token
+            )
+            auth_handler = url2.HTTPBasicAuthHandler(passman)
+        else:
+            auth_handler = url2.HTTPHandler()
+
+        if self.shotgun.config.proxy_handler:
+            # Re-use proxy settings from the Shotgun connection
+            opener = url2.build_opener(
+                self.parent.shotgun.config.proxy_handler,
+                auth_handler
+            )
+        else:
+            opener = url2.build_opener(auth_handler)
+
+        url2.install_opener(opener)
+        request = url2.Request(asset["url"])
+        if token:
+            # We will be redirected and the Auth shouldn't be in the header
+            # for the redirection.
+            request.add_unredirected_header("Authorization", "token %s" % token)
+        request.add_header("Accept", "application/octet-stream")
+        response = url2.urlopen(request)
+        if not os.path.exists(destination):
+            self.logger.info("Creating %s" % destination)
+            os.makedirs(destination)
+        tmp_file = os.path.join(destination, asset["name"])
+        with open(tmp_file, "wb") as f:
+            f.write(response.read())
+        with zipfile.ZipFile(tmp_file, "r") as zip_ref:
+            zip_ref.extractall(destination)


### PR DESCRIPTION
Added documentation for the framework, especially about Azure pipelines.
Copied over the bootstrap.py hook, as a starting point if people want to use the framework outside of our provided configs (it does not have to be reviewed).