### PR TITLE
Fixes and polish

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,53 @@
+# Copyright 2018 GPL Solutions, LLC.  All rights reserved.
+#
+# Use of this software is subject to the terms of the GPL Solutions license
+# agreement provided at the time of installation or download, or which otherwise
+# accompanies this software in either electronic or hard copy form.
+#
+
+# Flake 8 PEP and lint configuration - https://gitlab.com/pycqa/flake8
+#
+# This defines the official lint and PEP8 rules for this repository
+#
+# You can run this locally by doing pep install flake8 and then
+# >flake8 .
+
+[flake8]
+
+# Things we don't want to lint
+exclude =
+    .tox,
+    .git,
+    .flake8,
+    .gitignore,
+    .travis.yml,
+    .cache,
+    .eggs,
+    *.rst,
+    *.yml,
+    *.pyc,
+    *.pyo,
+    *.egg-info,
+    __pycache__,
+    # Those are our third parties, do not lint them
+    vendors,
+    # Skip __init__.py files, to not have a lot of 'xxx' imported but unused
+    python/__init__.py,
+    python/*/__init__.py,
+    # Skip the auto-generated ui file.
+    python/*/ui,
+    venv,
+    winenv,
+    osx_env,
+    win_env,
+
+# Ignore some errors
+#
+# E402 module level import not at top of file
+# E501 line too long (112 > 79 characters)
+# N802 Variables should be lower case. (clashes with Qt naming conventions)
+# N806 Variables should be lower case. (clashes with Qt naming conventions)
+# W503 line break before binary operator (it breaks before, not after)
+
+ignore = E501, E402, N802, N806, W503
+

--- a/framework.py
+++ b/framework.py
@@ -1,5 +1,5 @@
 # This file is based on templates provided and copyrighted by Autodesk, Inc.
-# This file has been modified by Epic Games, Inc. and is subject to the license 
+# This file has been modified by Epic Games, Inc. and is subject to the license
 # file included in this repository.
 
 """
@@ -22,7 +22,7 @@ class UnrealQtFramework(sgtk.platform.Framework):
 
     ##########################################################################################
     # init and destroy
-            
+
     def init_framework(self):
         """
         This framework ships with additional Python packages and tweak the Python
@@ -35,7 +35,7 @@ class UnrealQtFramework(sgtk.platform.Framework):
 
         # Check if PySide is already available, do nothing if it is the case
         try:
-            from sgtk.platform.qt import QtCore
+            from sgtk.platform.qt import QtCore  # noqa
             self.log_debug("Qt is already available, not activating any custom package.")
             return
         except ImportError as e:

--- a/hooks/core/bootstrap.py
+++ b/hooks/core/bootstrap.py
@@ -142,7 +142,7 @@ class Bootstrap(get_hook_baseclass()):
             for asset in response_d["assets"]:
                 name = asset["name"]
                 m = re.match(
-                    "%s-py\d.\d-%s.zip" % (version, pname),
+                    r"%s-py\d.\d-%s.zip" % (version, pname),
                     name
                 )
                 if m:

--- a/hooks/tk-multi-publish2/tk-maya/basic/collector.py
+++ b/hooks/tk-multi-publish2/tk-maya/basic/collector.py
@@ -21,7 +21,6 @@ class MayaSessionCollectorWithSecondaries(HookBaseClass):
         collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py:{config}/tk-multi-publish2/tk-maya/basic/collector.py"
     """
 
-
     def collect_current_maya_session(self, settings, parent_item):
         """
         Creates an item that represents the current maya session.

--- a/hooks/tk-multi-publish2/tk-maya/basic/publish_fbx.py
+++ b/hooks/tk-multi-publish2/tk-maya/basic/publish_fbx.py
@@ -187,7 +187,6 @@ class MayaFBXPublishPlugin(HookBaseClass):
         :raises ValueError: For problems which can't be solved in the current session.
         """
 
-        publisher = self.parent
         path = _session_path()
 
         # ---- ensure the session has been saved
@@ -282,7 +281,6 @@ class MayaFBXPublishPlugin(HookBaseClass):
             # Set the publish_path to be explicit.
             item.local_properties["publish_path"] = publish_path
 
-
         # Set the session path on the item for use by the base plugin validation
         # step.
         # NOTE: this path could change prior to the publish phase.
@@ -311,8 +309,6 @@ class MayaFBXPublishPlugin(HookBaseClass):
             instances.
         :param item: Item to process
         """
-
-        publisher = self.parent
 
         # Get the path in a normalized state. no trailing separator, separators
         # are appropriate for current os, no double separators, etc.
@@ -375,6 +371,7 @@ def _session_path():
         path = six.ensure_str(path)
 
     return path
+
 
 def _save_session(path):
     """

--- a/hooks/tk-multi-publish2/tk-maya/unreal/unreal_importer.py
+++ b/hooks/tk-multi-publish2/tk-maya/unreal/unreal_importer.py
@@ -1,19 +1,21 @@
-# Copyright 2018 Epic Games, Inc. 
+# Copyright 2018 Epic Games, Inc.
 
 import unreal
-import os
+import re
 import sys
 
 """
 Functions to import FBX into Unreal
 """
 
+
 def _sanitize_name(name):
     # Remove the default Shotgun versioning number if found (of the form '.v001')
     name_no_version = re.sub(r'.v[0-9]{3}', '', name)
-    
+
     # Replace any remaining '.' with '_' since they are not allowed in Unreal asset names
     return name_no_version.replace('.', '_')
+
 
 def _generate_fbx_import_task(
     filename,
@@ -36,11 +38,11 @@ def _generate_fbx_import_task(
     task = unreal.AssetImportTask()
     task.filename = filename
     task.destination_path = destination_path
-    
+
     # By default, destination_name is the filename without the extension
     if destination_name is not None:
         task.destination_name = destination_name
-        
+
     task.replace_existing = replace_existing
     task.automated = automated
     task.save = save
@@ -49,7 +51,7 @@ def _generate_fbx_import_task(
     task.options.import_materials = materials
     task.options.import_textures = textures
     task.options.import_as_skeletal = as_skeletal
-    
+
     task.options.static_mesh_import_data.combine_meshes = True
 
     task.options.mesh_type_to_import = unreal.FBXImportType.FBXIT_STATIC_MESH
@@ -57,6 +59,7 @@ def _generate_fbx_import_task(
         task.options.mesh_type_to_import = unreal.FBXImportType.FBXIT_SKELETAL_MESH
 
     return task
+
 
 def import_fbx(filename, destination_path):
     """
@@ -68,8 +71,10 @@ def import_fbx(filename, destination_path):
     unreal.AssetToolsHelpers.get_asset_tools().import_asset_tasks(tasks)
     unreal.EditorLoadingAndSavingUtils.save_dirty_packages(False, True)
 
+
 def main(argv):
     import_fbx(*argv)
+
 
 if __name__ == "__main__":
     # Script arguments must be, in order:


### PR DESCRIPTION
Ran code through Flake8 and fixed problems.

Fixed the following problems:
- Strings returned by Maya commands in Py2 (Maya 2020) were unicode and causing problems when used as environment variables in subprocess.
- In some cases publishes would be registered with a file:// url, added a `_get_local_path` method to handle all cases (local file, file:// url).
- Fixed a problem with UE5 "interpreting" \ in Python script path given in the command line.
