### PR TITLE
Fix for Maya FBX publisher and github_release example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,24 @@ frameworks:
 - If you're using a local descriptor (dev or path) you need to build the PySide2 libraries
 yourself. See [building the PySide2 libraries locally](#building-the-pyside2-libraries-locally).
 
-- If you're using a remote descriptor, just in time download must be added so these binaries are downloaded in SG TK bootstrap process. The provided [bootstrap.py](hooks/core/bootstrap.py) script implements just in time downloads from Github releases with a `git` descriptor:
+- If you're using a remote descriptor, just in time download must be added so these binaries are downloaded in SG TK bootstrap process. The provided [bootstrap.py](hooks/core/bootstrap.py) script implements just in time downloads from Github releases with a `git` or a `github_release` descriptor:
    - Copy the `hooks/core/bootstrap.py` file to your config `core/hooks/bootstrap.py`
 hook.
    - Use a `git` descriptor for the framework, e.g.:
       ```
       tk-framework-unrealqt_v1.x.x:
         location:
-          version: v1.2.5
+          version: v1.3.0
           type: git
           path: git@github.com:ue4plugins/tk-framework-unrealqt.git
+      ```
+   - Or use a `github_release` descriptor for the framework, e.g.:
+      ```
+      tk-framework-unrealqt_v1.x.x:
+        location:
+          version: v1.3.0
+          type: github_release
+          organization: ue4plugins
+          repository: tk-framework-unrealqt
       ```
 

--- a/hooks/core/bootstrap.py
+++ b/hooks/core/bootstrap.py
@@ -138,7 +138,7 @@ class Bootstrap(get_hook_baseclass()):
             for asset in response_d["assets"]:
                 name = asset["name"]
                 m = re.match(
-                    "%s-py\d.\d-%s.zip" % (version, pname),
+                    r"%s-py\d.\d-%s.zip" % (version, pname),
                     name
                 )
                 if m:

--- a/hooks/core/bootstrap.py
+++ b/hooks/core/bootstrap.py
@@ -54,11 +54,7 @@ class Bootstrap(get_hook_baseclass()):
         :raises RuntimeError: If six.moves is not available.
         """
         descd = descriptor.get_dict()
-        # Some descriptors like shotgun descriptors don't have a path: ignore
-        # them.
-        if not descd.get("path"):
-            return False
-        return bool(self._should_download_release(descd["path"]))
+        return bool(self._should_download_release(descd))
 
     def populate_bundle_cache_entry(self, destination, descriptor, **kwargs):
         """
@@ -92,7 +88,7 @@ class Bootstrap(get_hook_baseclass()):
         descd = descriptor.get_dict()
         version = descriptor.version
         self.logger.info("Treating %s" % descd)
-        specs = self._should_download_release(descd["path"])
+        specs = self._should_download_release(descd)
         if not specs:
             raise RuntimeError("Don't know how to download %s" % descd)
         name = specs[0]
@@ -142,7 +138,7 @@ class Bootstrap(get_hook_baseclass()):
             for asset in response_d["assets"]:
                 name = asset["name"]
                 m = re.match(
-                    r"%s-py\d.\d-%s.zip" % (version, pname),
+                    "%s-py\d.\d-%s.zip" % (version, pname),
                     name
                 )
                 if m:
@@ -171,17 +167,28 @@ class Bootstrap(get_hook_baseclass()):
             self.logger.exception(e)
             raise
 
-    def _should_download_release(self, desc_path):
+    def _should_download_release(self, desc):
         """
-        Return a repo name and a token if the given descriptor path should be downloaded
+        Return a repo name and a token if the given descriptor should be downloaded
         from a github release.
 
-        :param str desc_path: A Toolkit descriptor path.
+        :param str desc: A Toolkit descriptor.
         :returns: A name, token tuple or ``None``.
         """
-        for name, token in self._download_release_from_github:
-            if "git@github.com:%s.git" % name == desc_path:
-                return name, token
+        if desc["type"] == "github_release":
+            # Let's be safe...
+            if not desc.get("organization") or not desc.get("repository"):
+                return None
+            desc_path = "%s/%s" % (desc["organization"], desc["repository"])
+            for name, token in self._download_release_from_github:
+                if name == desc_path:
+                    return name, token
+        elif desc.get("path"):
+            # Check the path for a git descriptor
+            desc_path = desc["path"]
+            for name, token in self._download_release_from_github:
+                if "git@github.com:%s.git" % name == desc_path:
+                    return name, token
         return None
 
     def _download_zip_github_asset(self, asset, destination, token):

--- a/hooks/tk-multi-publish2/tk-maya/basic/publish_fbx.py
+++ b/hooks/tk-multi-publish2/tk-maya/basic/publish_fbx.py
@@ -157,7 +157,7 @@ class MayaFBXPublishPlugin(HookBaseClass):
 
             # We've validated the publish template. add it to the item properties
             # for use in subsequent methods
-            item.properties["publish_template"] = publish_template
+            item.local_properties["publish_template"] = publish_template
 
         path = _session_path()
         if not path:
@@ -226,7 +226,7 @@ class MayaFBXPublishPlugin(HookBaseClass):
         # matches. if not, warn the user and provide a way to save the file to
         # a different path
         work_template = item.properties.get("work_template")
-        publish_template = item.properties.get("publish_template")
+        publish_template = item.local_properties.get("publish_template")
         if work_template and publish_template:
             # Ensure the fields work for the publish template
             # This raises an error if the path does not match the template.
@@ -235,7 +235,7 @@ class MayaFBXPublishPlugin(HookBaseClass):
             if missing_keys:
                 error_msg = (
                     "Work file '%s' missing keys required for the "
-                    "publish template: %s" % (path, missing_keys)
+                    "publish template %s: %s" % (path, publish_template, missing_keys)
                 )
                 self.logger.error(error_msg)
                 return False

--- a/hooks/tk-multi-publish2/tk-maya/basic/publish_turntable.py
+++ b/hooks/tk-multi-publish2/tk-maya/basic/publish_turntable.py
@@ -672,7 +672,7 @@ class MayaUnrealTurntablePublishPlugin(HookBaseClass):
 
             # We've validated the publish template. add it to the item properties
             # for use in subsequent methods
-            item.properties["publish_template"] = publish_template
+            item.local_properties["publish_template"] = publish_template
 
             # Because a publish template is configured, disable context change. This
             # is a temporary measure until the publisher handles context switching
@@ -721,7 +721,7 @@ class MayaUnrealTurntablePublishPlugin(HookBaseClass):
 
         # get the configured work file template
         work_template = item.properties.get("work_template")
-        publish_template = item.properties.get("publish_template")
+        publish_template = item.local_properties.get("publish_template")
         if work_template and publish_template:
             # get the current scene path and extract fields from it using the work
             # template:


### PR DESCRIPTION
Fixed a problem with Maya FBX publisher when a Publish template is set in the SGTK configuration settings.
Added examples for using a `github_release` descriptor for this framework.