### PR TITLE
Python 3.11 and PySide6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ This is a helper library designed to be used in
 conjunction with the [tk-unreal](https://github.com/ue4plugins/tk-unreal) engine.
 
 This framework contains hooks which can be re-used in configurations where the
-Unreal integration is needed, and PySide2 binaries needed to run the SG Toolkit
+Unreal integration is needed, and PySide binaries needed to run the SG Toolkit
 integration in Unreal.
 
 Please see the engine for more details.
 
-## The PySide2 libraries
+## The PySide libraries
 
-Binaries for PySide2 libraries for all platforms are not included in the
+Binaries for PySide libraries for all platforms are not included in the
 source tree and must be built before being able to use this framework.
 
-### Building the PySide2 libraries locally
+### Building the PySide libraries locally
 
 Use the [build_packages.sh](resources/build_packages.sh) script with the `-b` option to build and install 
 the packages specified in the [requirements.txt](resources/requirements.txt) file.
@@ -28,7 +28,7 @@ Options :
 The framework can be used with a local descriptor (e.g. dev or path) once the 
 binaries are build. 
 
-### Building the PySide2 libraries with Azure Pipelines
+### Building the PySide libraries with Azure Pipelines
 
 The [build_packages.sh](resources/build_packages.sh) script can be used with [Azure Pipelines](https://docs.microsoft.com/en-us/azure/devops/pipelines/get-started/pipelines-get-started?view=azure-devops) 
 to automatically build the packages each time a new version tag is added in Github.
@@ -41,7 +41,7 @@ You can use the provided [azure-pipelines.yml](azure-pipelines.yml) file to crea
 A [service connection to Github](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#permissions-needed-in-github-1)
  will have to be created if you don't already have one.
 
-The Azure pipeline builds the PySide2 libraries for Windows, Linux and Mac, and upload them to Github releases.
+The Azure pipeline builds the PySide libraries for Windows, Linux and Mac, and upload them to Github releases.
 
 <img width="512" alt="Github releases" src="https://user-images.githubusercontent.com/39291844/153920988-0dcb80d3-3c37-479d-8079-33496f8952f4.png">
 
@@ -56,8 +56,8 @@ frameworks:
      - {"name": "tk-framework-unrealqt", "version": "v1.x.x"}
 ```
 
-- If you're using a local descriptor (dev or path) you need to build the PySide2 libraries
-yourself. See [building the PySide2 libraries locally](#building-the-pyside2-libraries-locally).
+- If you're using a local descriptor (dev or path) you need to build the PySide libraries
+yourself. See [building the PySide libraries locally](#building-the-pyside2-libraries-locally).
 
 - If you're using a remote descriptor, just in time download must be added so these binaries are downloaded in SG TK bootstrap process. The provided [bootstrap.py](hooks/core/bootstrap.py) script implements just in time downloads from Github releases with a `git` or a `github_release` descriptor:
    - Copy the `hooks/core/bootstrap.py` file to your config `core/hooks/bootstrap.py`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,18 +24,18 @@ jobs:
   strategy:
     matrix:
       # Define all the platform/python version we need
-      MacPython37:
+      MacPython311:
         platform: 'osx'  # Short name for us
-        imageName: 'macOS-10.15'
-        python.version: '3.7'
-      WinPython37:
+        imageName: 'macOS-latest'
+        python.version: '3.11'
+      WinPython311:
         platform: 'win' # Short name for us
-        imageName: 'windows-2019'
-        python.version: '3.7'
-      LinuxPython37:
+        imageName: 'windows-latest'
+        python.version: '3.11'
+      LinuxPython311:
         platform: 'linux'  # Short name for us
         imageName: 'ubuntu-latest'
-        python.version: '3.7'
+        python.version: '3.11'
     maxParallel: 1
 
   pool:
@@ -84,12 +84,9 @@ jobs:
     inputs:
       Contents: |
         .git
-        resources/packagevenv_osx_2
-        resources/packagevenv_osx_3
-        resources/packagevenv_windows_2
-        resources/packagevenv_windows_3
-        resources/packagevenv_linux_2
-        resources/packagevenv_linux_3
+        resources/packagevenv_osx_3.11
+        resources/packagevenv_windows_3.11
+        resources/packagevenv_linux_3.11
 
   # Archive files
   # Compress files into .7z, .tar.gz, or .zip

--- a/framework.py
+++ b/framework.py
@@ -75,7 +75,7 @@ class UnrealQtFramework(sgtk.platform.Framework):
                     "lib"
                 )
             )
-            python_pattern = r"^python%d\.\d$" % python_major
+            python_pattern = r"^python%d\.\d+$" % python_major
             for folder in lib_folders:
                 if re.match(python_pattern, folder):
                     break

--- a/framework.py
+++ b/framework.py
@@ -3,9 +3,9 @@
 # file included in this repository.
 
 """
-Framework containing PySide2 distributions for the Unreal engine
+Framework containing PySide distributions for the Unreal engine
 
-Because Unreal does not include PySide2/Qt distributions but does use its own
+Because Unreal does not include PySide/Qt distributions but does use its own
 version of Python, we have to distribute full versions for the engine to function.
 """
 
@@ -31,15 +31,15 @@ class UnrealQtFramework(sgtk.platform.Framework):
         Something similar to what `virtualenv` does is done when this framework is
         loaded by SG TK.
         """
-        self.log_debug("%s: Initializing UnrealQtFramework..." % self)
+        self.logger.debug("%s: Initializing UnrealQtFramework..." % self)
 
         # Check if PySide is already available, do nothing if it is the case
         try:
             from sgtk.platform.qt import QtCore  # noqa
-            self.log_debug("Qt is already available, not activating any custom package.")
+            self.logger.debug("Qt is already available, not activating any custom package.")
             return
         except ImportError as e:
-            self.log_debug("Qt is not available: %s, activating custom package." % e)
+            self.logger.debug("Qt is not available: %s, activating custom package." % e)
             pass
         # Remap the platform name to our names
         pname = self.platform_name()
@@ -53,13 +53,14 @@ class UnrealQtFramework(sgtk.platform.Framework):
         # Copied over from activate_this.py script which does not exist anymore
         # from Python 3.
         python_major = sys.version_info[0]  # 2 or 3
+        python_minor = sys.version_info[1]  # 6, 7, 8, etc
 
         base_path = os.path.realpath(
             os.path.join(
                 os.path.dirname(__file__),
                 "python",
                 "vendors",
-                "py%d" % python_major,
+                "py%d.%d" % (python_major, python_minor),
                 pname,
             )
         )
@@ -108,7 +109,7 @@ class UnrealQtFramework(sgtk.platform.Framework):
         sys.prefix = base_path
 
     def destroy_framework(self):
-        self.log_debug("%s: Destroying UnrealQtFramework..." % self)
+        self.logger.debug("%s: Destroying UnrealQtFramework..." % self)
 
     @classmethod
     def platform_name(cls):

--- a/hooks/core/bootstrap.py
+++ b/hooks/core/bootstrap.py
@@ -138,7 +138,7 @@ class Bootstrap(get_hook_baseclass()):
             for asset in response_d["assets"]:
                 name = asset["name"]
                 m = re.match(
-                    r"%s-py\d.\d-%s.zip" % (version, pname),
+                    r"%s-py\d.\d+-%s.zip" % (version, pname),
                     name
                 )
                 if m:

--- a/resources/build_packages.sh
+++ b/resources/build_packages.sh
@@ -133,15 +133,22 @@ echo "Detecting Python version..."
 python_version=$($python_cmd --version 2>&1)
 # 2 or 3
 python_major_version=${python_version:7:1}
-if [ -z $python_major_version ];
+# 2 or 3
+python_major_version=${python_version:7:1}
+# Remove patch number from Python 3.9.17
+no_patch=${python_version%\.*}
+# 3.9
+python_major_minor=${no_patch:7}
+
+if [ -z $python_major_version ] || [ -z $python_major_minor ];
 then
    echo "Unable to detect python version, aborting"
    exit 1
 fi
 
-echo "Detected python version ${python_major_version} from ${python_version}"
+echo "Detected python version ${python_major_version} from ${python_version} (${python_major_minor})"
 
-packagevenv="packagevenv_${platform_name}_${python_major_version}"
+packagevenv="packagevenv_${platform_name}_${python_major_minor}"
 if [ ! -d $packagevenv ]; then
     if [ ${python_major_version} == 2 ];
     then
@@ -200,8 +207,8 @@ if [ $do_build == 1 ]; then
     fi
     # Copy packages to their shipping destination
     if [ -d ./${packagevenv} ]; then
-        mkdir -p ../python/vendors/py${python_major_version}
-        target="../python/vendors/py${python_major_version}/${platform_name}"
+        mkdir -p ../python/vendors/py${python_major_minor}
+        target="../python/vendors/py${python_major_minor}/${platform_name}"
         if [ -d $target ]; then
             echo "Deleting previous build in $target"
             # Clean up git but don't fail if there is nothing matching

--- a/resources/build_packages.sh
+++ b/resources/build_packages.sh
@@ -133,8 +133,6 @@ echo "Detecting Python version..."
 python_version=$($python_cmd --version 2>&1)
 # 2 or 3
 python_major_version=${python_version:7:1}
-# 2 or 3
-python_major_version=${python_version:7:1}
 # Remove patch number from Python 3.9.17
 no_patch=${python_version%\.*}
 # 3.9

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,3 +1,3 @@
 ## The following requirements were added by pip --freeze:
 
-PySide2==5.15.2
+PySide6==6.7.0


### PR DESCRIPTION
 Changed requirements and build scripts to fetch PySide 6 and build for Python 3.11.
- Changed some regex patterns to accept more than one digit for the minor version number.
- Leverage TK `logger.debug` rather than calling `log_debug` which is deprecated.
- Changed PySide requirement to `PySide6==6.7.0`